### PR TITLE
Style: Update Add Habit and Add To Do buttons

### DIFF
--- a/pages/habits.tsx
+++ b/pages/habits.tsx
@@ -259,9 +259,9 @@ export default function HabitsPage() {
           </div>
           <button
             onClick={addHabit}
-            className="bg-green-600 text-white px-4 py-3 text-lg rounded shadow hover:bg-green-700"
+        className="bg-green-500 text-white font-medium text-base px-6 py-3 rounded-lg shadow-md hover:scale-105 hover:brightness-105 hover:shadow-lg active:scale-95 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-400 transform transition-all duration-200 ease-out"
           >
-            + Add Habit
+        <span className="font-bold text-lg">+</span> Add Habit
           </button>
         </div>
         <div className="space-y-4">

--- a/pages/todos.tsx
+++ b/pages/todos.tsx
@@ -338,8 +338,11 @@ function TodosPage() {
           }}
           className="flex-1 border rounded p-2 mr-2"
         />
-        <button onClick={addTodo} className="bg-[#569866] text-white rounded px-4 py-3 text-lg">
-          Add
+        <button
+          onClick={addTodo}
+          className="bg-green-500 text-white font-medium text-base px-6 py-3 rounded-lg shadow-md hover:scale-105 hover:brightness-105 hover:shadow-lg active:scale-95 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-400 transform transition-all duration-200 ease-out"
+        >
+          <span className="font-bold text-lg">+</span> Add To Do
         </button>
       </div>
 


### PR DESCRIPTION
I've updated the '+ Add Habit' button on the habits page and the '+ Add To Do' button on the to-do page with consistent styling according to UI/UX best practices.

Changes include:
- Green background color (#22C55E / Tailwind green-500).
- Medium-large rectangular shape with rounded corners (8px).
- Sans-serif font (16px, medium-weight) with a bolder/larger '+' symbol.
- Generous internal padding (12px vertical, 24px horizontal).
- Subtle drop shadow for depth.
- Hover effects: slight scale increase, enhanced shadow, brightness increase.
- Active state: slight scale down when pressed.
- Ensured clear focus states for accessibility.
- Smooth CSS transitions (0.2s ease) for all hover/active states.